### PR TITLE
Fix LM hash computation

### DIFF
--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -206,6 +206,26 @@ NTLMSSP_AV_RESTRICTIONS     = 0x08
 NTLMSSP_AV_TARGET_NAME      = 0x09
 NTLMSSP_AV_CHANNEL_BINDINGS = 0x0a
 
+# LM array conversion
+LM_ARRAY_CONVERT = [0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,
+	 16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,
+	 32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,
+	 48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,
+	 64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
+	 80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,
+	 96,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
+	 80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90, 123, 124, 125, 126, 127,
+	 -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+	 -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+	255, 173, 155, 156,  15, 157, 221,  21,  34,  67, 166, 174, 170,  45,  82,  95,
+	248, 241, 253,  51,  39, 230,  20, 250,  44,  49, 167, 175, 172, 171,  95, 168,
+	 65,  65,  65,  65, 142, 143, 146, 128,  69, 144,  69,  69,  73,  73,  73,  73,
+	 68, 165,  79,  79,  79,  79, 153,  88,  79,  85,  85,  85, 154,  89,  95, 225,
+	 65,  65,  65,  65, 142, 143, 146, 128,  69, 144,  69,  69,  73,  73,  73,  73,
+	 68, 165,  79,  79,  79,  79, 153, 246,  79,  85,  85,  85, 154,  89,  95,  89]
+LM_ARRAY_CONVERT2 = [0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021, 0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0x017D, 0x2018,
+	 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014, 0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0x017E, 0x0178]
+
 class AV_PAIRS:
     def __init__(self, data = None):
         self.fields = {}
@@ -744,10 +764,20 @@ def computeResponseNTLMv1(flags, serverChallenge, clientChallenge, serverName, d
 
 def compute_lmhash(password):
     # This is done according to Samba's encryption specification (docs/html/ENCRYPTION.html)
-    password = password.upper()
-    lmhash  = __DES_block(b(password[:7]), KNOWN_DES_INPUT)
-    lmhash += __DES_block(b(password[7:14]), KNOWN_DES_INPUT)
+    lmhash  = __DES_block(convertPwToLM(password[:7]), KNOWN_DES_INPUT)
+    lmhash += __DES_block(convertPwToLM(password[7:14]), KNOWN_DES_INPUT)
     return lmhash
+
+def convertPwToLM(password):
+    ret = b''
+    for c in password:
+        v = ord(c)
+        if v > 0 and v < 255:
+            ret += int.to_bytes(LM_ARRAY_CONVERT[v])
+        for val in LM_ARRAY_CONVERT2:
+            if val == v:
+                ret += int.to_bytes(val)
+    return ret
 
 def NTOWFv1(password, lmhash = '', nthash=''):
     if nthash != '':


### PR DESCRIPTION
For some reason, when performing NTLM connection, impacket always compute the LM hash of the provided password. However, this operation fails when using special characters ('µ') for example:

```
$ PYTHONPATH=$PWD examples/smbclient.py 'test:Passwordµ@192.168.88.134' -debug
Impacket for Exegol - v0.10.0 - Copyright 2022 Fortra - forked by ThePorgs

[+] Impacket Library Installation Path: /home/laxa/Documents/impacket/impacket
Traceback (most recent call last):
  File "/home/laxa/Documents/impacket/examples/smbclient.py", line 102, in main
    smbClient.login(username, password, domain, lmhash, nthash)
  File "/home/laxa/Documents/impacket/impacket/smbconnection.py", line 278, in login
    return self._SMBConnection.login(user, password, domain, lmhash, nthash)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/laxa/Documents/impacket/impacket/smb3.py", line 1009, in login
    type3, exportedSessionKey = ntlm.getNTLMSSPType3(auth, respToken['ResponseToken'], user, password, domain, lmhash, nthash)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/laxa/Documents/impacket/impacket/ntlm.py", line 631, in getNTLMSSPType3
    ntlmChallengeResponse = NTLMAuthChallengeResponse(user, password, ntlmChallenge['challenge'])
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/laxa/Documents/impacket/impacket/ntlm.py", line 446, in __init__
    lmhash = compute_lmhash(password)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/laxa/Documents/impacket/impacket/ntlm.py", line 749, in compute_lmhash
    lmhash += __DES_block(b(password[7:14]), KNOWN_DES_INPUT)
                          ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/six.py", line 644, in b
    return s.encode("latin-1")
           ^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'latin-1' codec can't encode character '\u039c' in position 1: ordinal not in range(256)
[-] 'latin-1' codec can't encode character '\u039c' in position 1: ordinal not in range(256)
```

The documentation in the code states that it follows the RFC (https://datatracker.ietf.org/doc/rfc2433/). However, this RFC does not state how to handle special characters.
Google did not came up with anything related for handling these characters. However, I found an online LM hash calculator (https://tobtu.com/lmntlm.php) that calculated the same LM hash value that a Windows computer.
The JavaScript code of this website was converted for impacket.
The code has not been extensively tested, it might be breaking connection to legacy computers if any error was introduced...