### PR TITLE
Add Filter Socks Connection via AdminStatus

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -148,6 +148,42 @@ class MiniShell(cmd.Cmd):
             else:
                 logging.info('No Relays Available!')
 
+    def do_admsocks(self, line):
+        headers = ["Protocol", "Target", "Username", "AdminStatus", "Port"]
+        url = "http://localhost:9090/ntlmrelayx/api/v1.0/relays"
+        try:
+            proxy_handler = ProxyHandler({})
+            opener = build_opener(proxy_handler)
+            response = Request(url)
+            r = opener.open(response)
+            result = r.read()
+            items = json.loads(result)
+
+        except Exception as e:
+            logging.error("ERROR: %s" % str(e))
+        else:
+          try:
+            if len(items) > 0:
+              new_list = [] # New dict to store the "items" JSON array
+              idx = 0
+              admonly = 'TRUE' # Search string for Admin
+              for line in items:
+                if admonly in line:
+                  new_list.insert(idx, line)
+                  idx += 1
+              if len(new_list) == 0:
+                print("\nNo Admin Sessions Available") # Do I really need to explain this?
+              else:
+                lineLen = len(new_list)
+                for i in range(lineLen):
+                  break
+              self.printTable(new_list, header=headers)
+          # Exception added to handle max() ValueError on the rowMaxLen in printTable function
+          except ValueError as e:
+            print()
+          else:
+              logging.info('No Relays Available!')
+                
     def do_startservers(self, line):
         if not self.serversRunning:
             start_servers(options, self.relayThreads)


### PR DESCRIPTION
https://github.com/fortra/impacket/pull/1463

---

### Filter SOCKS Connection via AdminStatus

This quality-of-life improvement helps manage a large number of SOCKS connections by filtering those with `AdminStatus` set to `True`. This feature is especially useful when you have numerous connections, but only a few with administrative access to a host.

#### Usage:

```sh
ntlmrelayx.py .... -socks
```

*Relays come in:*

```sh
ntlmrelayx> help
Documented commands (type help <topic>):
help  socks
Undocumented commands:
EOF  admsocks  exit  finished_attacks  startservers  stopservers  targets
```

### Key Features:
- **Filtering by AdminStatus**: Instantly access the most useful SOCKS connections by displaying only those with `AdminStatus` set to `True`.
- **Improved Usability**: Simplifies the process of identifying and managing valuable connections among numerous active SOCKS sessions.

---