### PR TITLE
Update GetUserSPNs.py (#1)

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -92,6 +92,7 @@ class GetUserSPNs:
         self.__saveTGS = cmdLineOptions.save
         self.__requestUser = cmdLineOptions.request_user
         self.__stealth = cmdLineOptions.stealth
+        self.__rc4 = cmdLineOptions.rc4
         if cmdLineOptions.hashes is not None:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
 
@@ -313,6 +314,9 @@ class GetUserSPNs:
         if self.__requestUser is not None:
             searchFilter += '(sAMAccountName:=%s)' % self.__requestUser
 
+        if self.__rc4 is True:
+            searchFilter += '(!(msds-supportedencryptiontypes:1.2.840.113556.1.4.804:=24))'
+
         searchFilter += ')'
 
         try:
@@ -507,6 +511,7 @@ if __name__ == '__main__':
                         help='Output filename to write ciphers in JtR/hashcat format. Auto selects -request')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output.')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-rc4', action='store_true', default=False, help='Only requests users who do not support AES (avoid MDI downgrade detection)')
 
     group = parser.add_argument_group('authentication')
 


### PR DESCRIPTION
https://github.com/fortra/impacket/pull/1852
* Update GetUserSPNs.py

Added rc4 only request option so it only requests users who do not support AES (avoid MDI downgrade detection). Like /rc4opsec option in Rubeus

* Update GetUserSPNs.py

Fixed Copyright Fortra...etc comment on line 4 to be in line with new copyright info.