### PR TITLE
Add fallback to SIMPLE bind when NTLM fails (e.g. userWorkstations restriction)

### DIFF
--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -250,7 +250,7 @@ def _init_ldap_connection(target, tls_version, domain, username, password, lmhas
         # Try NTLM bind first without auto_bind to handle fallback
         ldap_session = ldap3.Connection(ldap_server, user=user, password=password, authentication=ldap3.NTLM, auto_bind=False)
         try:
-            if ldap_session.bind():i
+            if ldap_session.bind():
                 print("[+] NTLM bind succeeded.") # Informative message on successful NTLM bind
             else:
                 # Extract and print LDAP bind error code if available

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -209,8 +209,25 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     connection.bound = True
 
     return True
+# Modified by azox: added fallback to SIMPLE bind and LDAP error code printing for better debug
+
+
+LDAP_ERROR_CODES = {
+    '525': 'User not found',
+    '530': 'Not permitted to logon at this time',
+    '531': 'Not permitted to logon from this workstation',
+    '532': 'Password expired',
+    '533': 'Account disabled',
+    '701': 'Account expired',
+    '773': 'User must reset password',
+    '775': 'Account locked'
+}
+
 
 def _init_ldap_connection(target, tls_version, domain, username, password, lmhash, nthash, k, dc_ip, aesKey):
+    from ldap3.core.exceptions import LDAPBindError
+    import re
+
     user = '%s\\%s' % (domain, username)
     connect_to = target
     if dc_ip is not None:
@@ -224,13 +241,37 @@ def _init_ldap_connection(target, tls_version, domain, username, password, lmhas
         port = 389
         tls = None
     ldap_server = ldap3.Server(connect_to, get_info=ldap3.ALL, port=port, use_ssl=use_ssl, tls=tls)
+
     if k:
         ldap_session = ldap3.Connection(ldap_server)
         ldap_session.bind()
         ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, aesKey, kdcHost=dc_ip)
     elif lmhash == '' and nthash == '':
-        ldap_session = ldap3.Connection(ldap_server, user=user, password=password, authentication=ldap3.NTLM, auto_bind=True)
+        # Try NTLM bind first without auto_bind to handle fallback
+        ldap_session = ldap3.Connection(ldap_server, user=user, password=password, authentication=ldap3.NTLM, auto_bind=False)
+        try:
+            if ldap_session.bind():i
+                print("[+] NTLM bind succeeded.") # Informative message on successful NTLM bind
+            else:
+                # Extract and print LDAP bind error code if available
+                error_message = ldap_session.result.get('message', '')
+                match = re.search(r'data\s+([0-9a-f]{3})', error_message, re.IGNORECASE)
+                if match:
+                    data_code = match.group(1).lower()
+                    explanation = LDAP_ERROR_CODES.get(data_code, 'Unknown LDAP error code')
+                    print(f"[!] NTLM bind failed with LDAP error code: {data_code} ({explanation})")
+                else:
+                    print("[!] NTLM bind failed with unknown error.")
+
+                # Fallback to SIMPLE bind using UPN format (username@domain)
+                user_upn = f"{username}@{domain}"
+                ldap_session = ldap3.Connection(ldap_server, user=user_upn, password=password, authentication=ldap3.SIMPLE, auto_bind=True)
+                print("[*] SIMPLE bind succeeded.") # Informative message on fallback success
+        except LDAPBindError as e:
+            print(f"[!] LDAP bind failed: {e}")  # General bind failure catch
+            raise
     else:
+        # Bind using NTLM and password hash
         ldap_session = ldap3.Connection(ldap_server, user=user, password=lmhash + ":" + nthash, authentication=ldap3.NTLM, auto_bind=True)
 
     return ldap_server, ldap_session


### PR DESCRIPTION
Original PR on fortra/impacket: https://github.com/fortra/impacket/pull/1971

While working in an Active Directory environment, I encountered an issue where Impacket tools like `rbcd.py` failed to perform an LDAP bind, even though the credentials were valid.

The tool was returning:

![1](https://github.com/user-attachments/assets/a9f6ead0-fa4d-44da-8632-b3145b7c4419)

After investigation, I found that the failure was caused by the `userWorkstations` LDAP attribute being set for the user. This attribute restricts which machines the user can log on from. Since NTLM authentication includes the client's hostname, the Domain Controller applied this restriction and rejected the bind.

Example of a user with `userWorkstations: dc02` set:

![2](https://github.com/user-attachments/assets/25f24e9f-824c-46b4-823e-7629afd16d75)


As a workaround, I modified the `_init_ldap_connection()` function to:
- Attempt a NTLM bind first.
- If it fails, print the LDAP error code (e.g. `data 531`) and fallback to a SIMPLE bind.

This allowed the bind to succeed, as shown here:

![3](https://github.com/user-attachments/assets/7d850078-4eb4-4c38-8fd3-b013df85d5eb)


### Summary of changes:
- Added a fallback to `ldap3.SIMPLE` if NTLM fails
- Added debug output for NTLM bind failures (LDAP error code + human-readable explanation)

⚠️ Note: SIMPLE bind sends credentials in plain text unless LDAPS is used. Use with caution and only when appropriate. This change has also been applied to other LDAP-based tools in Impacket, including `dacledit.py` and `owneredit.py`, to improve reliability in similar environments.