### PR TITLE
GetNPUser.py: Single targets now correctly outputs hash to file

### DIFF
--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -257,6 +257,8 @@ class GetUserNoPreAuth:
             logging.info('Getting TGT for %s' % self.__username)
             entry = self.getTGT(self.__username)
             self.outputTGT(entry, fd)
+            if fd is not None:
+                fd.close()      
             return
 
         # Connect to LDAP
@@ -280,7 +282,9 @@ class GetUserNoPreAuth:
                 # Cannot authenticate, we will try to get this users' TGT (hoping it has PreAuth disabled)
                 logging.info('Cannot authenticate %s, getting its TGT' % self.__username)
                 entry = self.getTGT(self.__username)
-                self.outputTGT(entry, fd)
+                self.outputTGT(entry, fd)     
+                if fd is not None:
+                    fd.close()       
                 return
 
 


### PR DESCRIPTION
Original PR on fortra/impacket: https://github.com/fortra/impacket/pull/1867

Resolves #1568

Currently, GetNPUser.py does not write hashes to a file if an output file is specified **and a user file is not specified.** 

Copied the file-handling code in ```request_multiple_TGTs``` and put it in the appropriate areas.