### PR TITLE
secretsdump.py: Dumping credentials without touching disk

### DIFF
--- a/impacket/dcerpc/v5/rrp.py
+++ b/impacket/dcerpc/v5/rrp.py
@@ -853,7 +853,17 @@ def hBaseRegGetKeySecurity(dce, hKey, securityInformation = OWNER_SECURITY_INFOR
     request['hKey'] = hKey
     request['SecurityInformation'] = securityInformation
     request['pRpcSecurityDescriptorIn']['lpSecurityDescriptor'] = NULL
-    request['pRpcSecurityDescriptorIn']['cbInSecurityDescriptor'] = 1024
+    request['pRpcSecurityDescriptorIn']['cbInSecurityDescriptor'] = 4096
+
+    return dce.request(request)
+
+def hBaseRegSetKeySecurity(dce, hKey, sd, securityInformation = OWNER_SECURITY_INFORMATION):
+    request = BaseRegSetKeySecurity()
+    request['hKey'] = hKey
+    request['SecurityInformation'] = securityInformation
+    request['pRpcSecurityDescriptor']['lpSecurityDescriptor'] = sd.getData()
+    request['pRpcSecurityDescriptor']['cbInSecurityDescriptor'] = len(sd.getData())
+    request['pRpcSecurityDescriptor']['cbOutSecurityDescriptor'] = len(sd.getData())
 
     return dce.request(request)
 


### PR DESCRIPTION
Original PR on fortra/impacket: https://github.com/fortra/impacket/pull/1698

This PR allows to remotely extract hashes from the **SAM** and **SECURITY** (LSA Secrets and cached credentials) registry hives without touching disk. There is no need to save these registry hives to disk and parse them locally.

This feature takes advantage of the **WriteDACL** privileges held by local administrators to provide temporary read permissions on registry hives. This work was already implemented by @jfjallid on the great tool https://github.com/jfjallid/go-secdump.

In order to use this technique, it is required to use the `-inline` flag. If a connection error occurs and the extraction is interrupted, the `-restore` flag can be used to restore the initial state of the registry.

![secretsdump_inline](https://github.com/fortra/impacket/assets/22861294/c7b1024c-ba62-4737-b159-7d11d0443ca3)

Also, the `-use-ntds` flag has been added as I noticed it was trying to launch the NTDS extraction every time the script was launched.