### PR TITLE
Add TDO password dump on secretsdump

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -110,6 +110,7 @@ class DumpSecrets:
         self.__resumeFileName = options.resumefile
         self.__canProcessSAMLSA = True
         self.__kdcHost = options.dc_ip
+        self.__dumpTdo = options.dump_tdo
         self.__options = options
 
         if options.hashes is not None:
@@ -274,7 +275,7 @@ class DumpSecrets:
                                                useVSSMethod=self.__useVSSMethod, justNTLM=self.__justDCNTLM,
                                                pwdLastSet=self.__pwdLastSet, resumeSession=self.__resumeFileName,
                                                outputFileName=self.__outputFileName, justUser=self.__justUser,
-                                               ldapFilter=self.__ldapFilter, printUserStatus=self.__printUserStatus)
+                                               ldapFilter=self.__ldapFilter, printUserStatus=self.__printUserStatus, dumpTdo=self.__dumpTdo)
                 try:
                     self.__NTDSHashes.dump()
                 except Exception as e:
@@ -364,6 +365,8 @@ if __name__ == '__main__':
                         help='base output filename. Extensions will be added for sam, secrets, cached and ntds')
     parser.add_argument('-use-vss', action='store_true', default=False,
                         help='Use the VSS method instead of default DRSUAPI')
+    parser.add_argument('-dump-tdo', action='store_true', default=False,
+                        help='Try to dump CLEAR trusts password (LOCAL NTDS only)')
     parser.add_argument('-rodcNo', action='store', type=int, help='Number of the RODC krbtgt account (only avaiable for Kerb-Key-List approach)')
     parser.add_argument('-rodcKey', action='store', help='AES key of the Read Only Domain Controller (only avaiable for Kerb-Key-List approach)')
     parser.add_argument('-use-keylist', action='store_true', default=False,
@@ -436,6 +439,11 @@ if __name__ == '__main__':
         else:
             # Having this switch on implies not asking for anything else.
             options.just_dc = True
+
+    if options.dump_tdo is True:
+        if remoteName.upper() != 'LOCAL':
+            logging.error('-dump-tdo not compatible with remote target')
+            sys.exit(1)
 
     if options.use_vss is True and options.resumefile is not None:
         logging.error('resuming a previous NTDS.DIT dump session is not supported in VSS mode')


### PR DESCRIPTION
Original PR on fortra/impacket: https://github.com/fortra/impacket/pull/1505

Add the possibility to extract TDO password from local NTDS.  
Add the change to the secretsdump example to make it available directly from commandline.

It is now possible to retrieve all trust information, print them and dump them into the outputfile.

Was tested against a dozen of NTDS from Windows 2012 to Windows 2019. It did not in any case impact the other secretsdump features during the dump.

The option must be explicitly activated through the secretsdump command line to be used during the dump. Otherwise, the classic dump is performed.