### PR TITLE
added machineAccountQuota.py

### DIFF
--- a/examples/machineAccountQuota.py
+++ b/examples/machineAccountQuota.py
@@ -5,7 +5,8 @@
 
 # Description:
 #   This module will try to get the Machine Account Quota from the domain attribute ms-DS-MachineAccountQuota.
-#   If the value is superior to 0, it tries to list any computer object created by a user and returns the machine name and its creator sAMAccountName and SID.
+#   If the value is superior to 0, it tries to list any computer object created by a user and returns the machine
+#   name and its creator sAMAccountName and SID.
 #
 #   Author:
 #       TahiTi


### PR DESCRIPTION
Original PR on fortra/impacket: https://github.com/fortra/impacket/pull/1280

Created an impacket script to find the value of the domain attribute ms-DS-MachineAccountQuota.
When the value of the attribute is not 0, the script looks for any user that added a computer object to the domain. If there are any, it returns the machine name, the creator sAMAccountName and its SID.

![image](https://user-images.githubusercontent.com/3107859/165346914-df91caec-72a9-41e2-a7de-b92e2d6a3144.png)


