### PR TITLE
Added renameMachine.py

### DIFF
--- a/examples/renameMachine.py
+++ b/examples/renameMachine.py
@@ -209,6 +209,9 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
 
 def init_ldap_connection(target, tls_version, args, domain, username, password, lmhash, nthash):
     user = '%s\\%s' % (domain, username)
+    connect_to = target
+    if args.dc_ip is not None:
+        connect_to = args.dc_ip
     if tls_version is not None:
         use_ssl = True
         port = 636
@@ -217,7 +220,7 @@ def init_ldap_connection(target, tls_version, args, domain, username, password, 
         use_ssl = False
         port = 389
         tls = None
-    ldap_server = ldap3.Server(target, get_info=ldap3.ALL, port=port, use_ssl=use_ssl, tls=tls)
+    ldap_server = ldap3.Server(connect_to, get_info=ldap3.ALL, port=port, use_ssl=use_ssl, tls=tls)
     if args.k:
         ldap_session = ldap3.Connection(ldap_server)
         ldap_session.bind()


### PR DESCRIPTION
Original PR on fortra/impacket: https://github.com/fortra/impacket/pull/1224

Preparing a Pull Request that introduces scripts that allow to exploit the Kerberos sAMAccountName spoofing attacks (CVE-2021-42278 + CVE-2021-42287).

This attack chain allows regular users to spoof domain controllers.
The requirement to this attack is to have an unpatched KDC and full control over a machine account (to be able to edit its `sAMAccountName` and `servicePrincipalName` attributes). Full control over a machine account can be gained by creating it in the first place (e.g. by leveraging the `MachineAccountQuota` domain-level attribute if it's greater than 0)

![Screenshot from 2021-12-10 22-21-10](https://user-images.githubusercontent.com/40902872/145644376-0b964467-cac2-48b5-a634-b0f90f97ec50.png)

# References
- https://exploit.ph/cve-2021-42287-cve-2021-42278-weaponisation.html
- https://www.thehacker.recipes/ad/movement/kerberos/samaccountname-spoofing